### PR TITLE
[WIP] Manage data dialog

### DIFF
--- a/qgreenland.py
+++ b/qgreenland.py
@@ -175,6 +175,14 @@ class QGreenland:
             callback=self.run_download,
             parent=self.iface.mainWindow())
 
+        self.add_action(
+            icon_path,
+            text=self.tr(u'Manage Data'),
+            callback=self.run_manage_data,
+            add_to_toolbar=False,
+            parent=self.iface.mainWindow()
+            )
+
 
         # will be set False in run()
         self.first_start = True
@@ -215,3 +223,15 @@ class QGreenland:
 
         if result:
             pass
+
+    
+    def run_manage_data(self):
+
+        self.manage_dlg = QGreenlandDownload()
+        # call the method to fill the manage tree
+        self.manage_dlg._fill_manage_tree()
+        # set the tab to the correct index
+        self.manage_dlg.stackedWidget.setCurrentIndex(2)
+
+        self.manage_dlg.exec()
+

--- a/qgreenland_dowload.py
+++ b/qgreenland_dowload.py
@@ -24,7 +24,6 @@
 
 import os
 import json
-import platform
 
 from qgis.PyQt import uic, QtWidgets
 from qgis.PyQt.QtWidgets import (

--- a/qgreenland_dowload.py
+++ b/qgreenland_dowload.py
@@ -424,7 +424,7 @@ class QGreenlandDownload(QtWidgets.QDialog, FORM_CLASS):
             # add the icons depending on the checksum
             # only if the json file in the profile folder exists
             try:
-                for static_layer in downloaded_layers:
+                for static_layer in self.downloaded_layers:
                     for i in static_layer['assets']:
                         # check if the layer of the manifest is in the static json file of the profile folder
                         if layer['id'] in static_layer['id']:

--- a/qgreenland_dowload.py
+++ b/qgreenland_dowload.py
@@ -454,7 +454,7 @@ class QGreenlandDownload(QtWidgets.QDialog, FORM_CLASS):
                                     child.setIcon(QIcon(os.path.join(os.path.dirname(__file__), 'icons','uptodate.png')))
                                     child.setToolTip(self.tr("You already have the most recent data downloaded"))
                                 # if the checksum is not the same - warn the user with the specified icon
-                                elif layer['assets'][0]['checksum'] != i['checksum']:
+                                else:
                                     child.setIcon(QIcon(os.path.join(os.path.dirname(__file__), 'icons','outdate.png')))
                                     child.setToolTip(self.tr("A more recent version of the file is available"))
             except:

--- a/qgreenland_dowload.py
+++ b/qgreenland_dowload.py
@@ -24,6 +24,7 @@
 
 import os
 import json
+import platform
 
 from qgis.PyQt import uic, QtWidgets
 from qgis.PyQt.QtWidgets import (
@@ -146,6 +147,8 @@ class QGreenlandDownload(QtWidgets.QDialog, FORM_CLASS):
             # also enable the download button
             self.download_button.setEnabled(True)
         
+        self.explore_files_button.clicked.connect(self.open_folder)
+
     def get_server_url(self):
 
         # create an instance of the QGreenlandServer class
@@ -808,3 +811,17 @@ class QGreenlandDownload(QtWidgets.QDialog, FORM_CLASS):
 
         # set the text box with the folder path chosen
         self.folder_path.setText(self.saving_folder)
+
+
+    def open_folder(self):
+        """
+        open the directory on external file browser
+
+        be aware that we should check the platform and use different methods
+        """
+
+        folder_path = self.settings.value("/QGreenland/saving_folder")
+        if platform.system() == 'Windows':
+            os.startfile(folder_path)
+        else:
+            os.system(f"open {folder_path}")

--- a/qgreenland_dowload.py
+++ b/qgreenland_dowload.py
@@ -32,7 +32,12 @@ from qgis.PyQt.QtWidgets import (
     QMessageBox
 )
 from qgis.PyQt.QtCore import QSortFilterProxyModel, QUrl, QModelIndex
-from qgis.PyQt.QtGui import QIcon, QStandardItemModel, QStandardItem
+from qgis.PyQt.QtGui import (
+    QIcon,
+    QStandardItemModel,
+    QStandardItem,
+    QDesktopServices
+)
 from qgis.PyQt.Qt import Qt
 from qgis.PyQt.QtNetwork import QNetworkRequest
 
@@ -843,11 +848,7 @@ class QGreenlandDownload(QtWidgets.QDialog, FORM_CLASS):
         """
 
         folder_path = self.settings.value("/QGreenland/saving_folder")
-        if platform.system() == 'Windows':
-            os.startfile(folder_path)
-        else:
-            os.system(f"open {folder_path}")
-
+        QDesktopServices.openUrl(QUrl.fromLocalFile(folder_path))
 
     def load_layers(self):
         """

--- a/ui/qgreenland_download_dialog.ui
+++ b/ui/qgreenland_download_dialog.ui
@@ -182,14 +182,7 @@
      </widget>
      <widget class="QWidget" name="manage_data">
       <layout class="QGridLayout" name="gridLayout">
-       <item row="1" column="2">
-        <widget class="QCheckBox" name="checkBox">
-         <property name="text">
-          <string>Include Folder Structure</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0" colspan="4">
+       <item row="1" column="0" colspan="4">
         <widget class="QSplitter" name="splitter_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -202,17 +195,37 @@
          <widget class="QTextBrowser" name="summary_text_manage"/>
         </widget>
        </item>
-       <item row="1" column="3">
-        <widget class="QPushButton" name="pushButton_2">
+       <item row="2" column="0">
+        <widget class="QPushButton" name="explore_files_button">
+         <property name="text">
+          <string>Explore Files</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QCheckBox" name="folder_structure_check">
+         <property name="text">
+          <string>Include Folder Structure</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="QPushButton" name="add_to_project_button">
          <property name="text">
           <string>Add to Project</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="QPushButton" name="pushButton">
+       <item row="0" column="0">
+        <widget class="QLabel" name="load_data_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
-          <string>Explore Files</string>
+          <string>Please select layers on your computer to add to your project</string>
          </property>
         </widget>
        </item>

--- a/ui/qgreenland_download_dialog.ui
+++ b/ui/qgreenland_download_dialog.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>QGreenlandDownload</class>
  <widget class="QDialog" name="QGreenlandDownload">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/ui/qgreenland_download_dialog.ui
+++ b/ui/qgreenland_download_dialog.ui
@@ -180,6 +180,44 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="manage_data">
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="1" column="2">
+        <widget class="QCheckBox" name="checkBox">
+         <property name="text">
+          <string>Include Folder Structure</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="4">
+        <widget class="QSplitter" name="splitter_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <widget class="QTreeView" name="treeView_manage">
+          <property name="headerHidden">
+           <bool>true</bool>
+          </property>
+         </widget>
+         <widget class="QTextBrowser" name="summary_text_manage"/>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QPushButton" name="pushButton_2">
+         <property name="text">
+          <string>Add to Project</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QPushButton" name="pushButton">
+         <property name="text">
+          <string>Explore Files</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
This PR introduces many stuff:

* minor code cleaning
* make the dialog not modal to always interact with QGIS even if the dialog is opened
* open the download folder to browse the files
* load all the files into the legend
* better output of the progress bar
* add the manage data wizard: this can be opened from teh `Web -> QGreenland` menu or it is the last tab of the existing stacked widget

Still missing the chance to load the layers with the folder structure (load `Include folder structure` checkbox is not doing anything right now.

Fix #11 

@MattF-NSIDC @trey-stafford also without the last option to include the folder structure I think, after your tests of course, that we are nearly ready for a beta release!