### PR TITLE
Close the main dialog if not url in QgsSettings ref #32

### DIFF
--- a/qgreenland_dowload.py
+++ b/qgreenland_dowload.py
@@ -175,8 +175,9 @@ class QGreenlandDownload(QtWidgets.QDialog, FORM_CLASS):
             # execute the QGreenlandServer dialog
             qgreenland_server.exec()
 
-            # get the chose url
+            # get the chosen url
             self.downloading_url = qgreenland_server.get_server()
+            self.close()
 
         else:
             # grab the url directly from the QgsSettings


### PR DESCRIPTION
I tried on a clean QGIS profile, so without anything written in the `QGIS/QGIS.ini` file. To test it you can open the `QGIS/QGIS.ini` file and delete all the lines (if any) related to QGreenland. In my case:

```
[QGreenland]
server-chosen=true
server-url=http://qgreenland.apps.nsidc.org/layers/
```

just delete all of them. Or you can start a clean QGIS profile.

Let me know if this small fix fixes the issue